### PR TITLE
feat/drawer_designed

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,19 @@
 # 미세먼지 앱 개발 노트
 
-2023/08/20 (일)
-
-### SliverAppBar
+### 2023/08/20 (일) - SliverAppBar
 
 ---
 
 <center><h3>Files List</h3></center>
 
-<img width="399" alt="image" src="https://github.com/baka9131/project-dusty-dust/assets/93738662/c2a81efc-d7ba-4d8a-890b-9259c2285d3b">
+<p align="center"><img width="399" alt="image" src="https://github.com/baka9131/project-dusty-dust/assets/93738662/c2a81efc-d7ba-4d8a-890b-9259c2285d3b"></p>
 
 ---
 
 
-
+<p align="center">
 <img width="318" alt="image" src="https://github.com/baka9131/project-dusty-dust/assets/93738662/55ce0dd2-025a-4719-a78c-54e2470b5e15">
+</p>
 
 + 상하 위 아래로 스크롤이 가능한 AppBar를 구현
 

--- a/lib/component/main_app_bar.dart
+++ b/lib/component/main_app_bar.dart
@@ -21,43 +21,46 @@ class MainAppBar extends StatelessWidget {
       flexibleSpace: FlexibleSpaceBar(
         // AppBar의 상하 스크롤 (FlexibleSpaceBar)
         background: SafeArea(
-          child: Column(
-            children: [
-              Text(
-                '서울',
-                style: ts.copyWith(
-                  fontSize: 40.0,
-                  fontWeight: FontWeight.w700,
+          child: Container(
+            margin: EdgeInsets.only(top: kToolbarHeight), // 앱바의 시스템상 높이값을 가져옴
+            child: Column(
+              children: [
+                Text(
+                  '서울',
+                  style: ts.copyWith(
+                    fontSize: 40.0,
+                    fontWeight: FontWeight.w700,
+                  ),
                 ),
-              ),
-              Text(
-                formatDate,
-                style: ts.copyWith(
-                  fontSize: 20.0,
+                Text(
+                  formatDate,
+                  style: ts.copyWith(
+                    fontSize: 20.0,
+                  ),
                 ),
-              ),
-              const SizedBox(height: 20.0),
-              Image.asset(
-                'asset/img/mediocre.png',
-                width: MediaQuery.of(context).size.width / 2,
-              ),
-              const SizedBox(height: 20.0),
-              Text(
-                '보통',
-                style: ts.copyWith(
-                  fontSize: 40.0,
-                  fontWeight: FontWeight.w700,
+                const SizedBox(height: 20.0),
+                Image.asset(
+                  'asset/img/mediocre.png',
+                  width: MediaQuery.of(context).size.width / 2,
                 ),
-              ),
-              const SizedBox(height: 8.0),
-              Text(
-                '나쁘지 않네요!',
-                style: ts.copyWith(
-                  fontSize: 20.0,
-                  fontWeight: FontWeight.w700,
+                const SizedBox(height: 20.0),
+                Text(
+                  '보통',
+                  style: ts.copyWith(
+                    fontSize: 40.0,
+                    fontWeight: FontWeight.w700,
+                  ),
                 ),
-              ),
-            ],
+                const SizedBox(height: 8.0),
+                Text(
+                  '나쁘지 않네요!',
+                  style: ts.copyWith(
+                    fontSize: 20.0,
+                    fontWeight: FontWeight.w700,
+                  ),
+                ),
+              ],
+            ),
           ),
         ),
       ),

--- a/lib/component/main_drawer.dart
+++ b/lib/component/main_drawer.dart
@@ -1,0 +1,57 @@
+import 'package:dusty_dust/const/colors.dart';
+import 'package:flutter/material.dart';
+
+const regions = [
+  '서울',
+  '경기',
+  '대구',
+  '충남',
+  '인천',
+  '대전',
+  '경북',
+  '세종',
+  '광주',
+  '전북',
+  '강원',
+  '울산',
+  '전남',
+  '부산',
+  '제주',
+  '충북',
+  '경남',
+];
+
+class MainDrawer extends StatelessWidget {
+  const MainDrawer({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Drawer(
+      backgroundColor: darkColor,
+      child: ListView(
+        children: [
+          DrawerHeader(
+            // 타이틀 부분
+            child: Text(
+              '지역 선택',
+              style: TextStyle(
+                color: Colors.white,
+                fontSize: 20.0,
+              ),
+            ),
+          ),
+          ...regions.map( // casecade 문법으로 리스트를 하나씩 Widget형태로 반환해줌 
+            (e) => ListTile(
+              tileColor: Colors.white,
+              selectedTileColor: lightColor, // 선택이 된 상태에서 배경색
+              selectedColor: Colors.black, // 선택이 된 상태에서의 글자 색깔
+              selected: e == '서울', // selected 를 사용할 것인지 여부
+              onTap: () {},
+              title: Text(e),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/const/colors.dart
+++ b/lib/const/colors.dart
@@ -1,3 +1,7 @@
 import 'package:flutter/material.dart';
 
 const primaryColor = Color(0xFF009688);
+
+const darkColor = Color(0xFF00675B);
+
+const lightColor = Color(0xFF52C7B8);

--- a/lib/screen/home_screen.dart
+++ b/lib/screen/home_screen.dart
@@ -1,4 +1,5 @@
 import 'package:dusty_dust/component/main_app_bar.dart';
+import 'package:dusty_dust/component/main_drawer.dart';
 import 'package:dusty_dust/const/colors.dart';
 import 'package:flutter/material.dart';
 
@@ -8,6 +9,7 @@ class HomeScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
+      drawer: MainDrawer(),
       backgroundColor: primaryColor,
       body: CustomScrollView(
         slivers: [


### PR DESCRIPTION
### 2023/08/21 (월) - Drawer

<center><h3>Files List</h3></center>

<p align="center"><img width="334" alt="image" src="https://github.com/baka9131/project-dusty-dust/assets/93738662/58e6ddcb-a6e0-4295-8638-08b4a50a4615"></p>

---

<p align="center">
<img width="313" alt="image" src="https://github.com/baka9131/project-dusty-dust/assets/93738662/d2bdc183-3879-44ea-abac-7338cb23c517">
</p>




+ Drawer 위젯을 통해 AppBar를 통해 리스트 목록을 구현



```dart
  Widget build(BuildContext context) {
    return Drawer(
      backgroundColor: darkColor,
      child: ListView(
        children: [
          DrawerHeader(
            // 타이틀 부분
            child: Text(
              '지역 선택',
              style: TextStyle(
                color: Colors.white,
                fontSize: 20.0,
              ),
            ),
          ),
          ...regions.map( // casecade 문법으로 리스트를 하나씩 Widget형태로 반환해줌 
            (e) => ListTile(
              tileColor: Colors.white,
              selectedTileColor: lightColor, // 선택이 된 상태에서 배경색
              selectedColor: Colors.black, // 선택이 된 상태에서의 글자 색깔
              selected: e == '서울', // selected 를 사용할 것인지 여부
              onTap: () {},
              title: Text(e),
            ),
          ),
        ],
      ),
    );
  }
```



+ 새롭게 배운 부분

```
... casecade 을 이용하여 아래의 오류를 해결하였다
```

<img width="605" alt="image" src="https://github.com/baka9131/project-dusty-dust/assets/93738662/f298544b-68cb-41bf-8a04-c843c572ba3d">

```markdown
List<String> 선언된 여러 리스트를 map()을 통해 Drawer에 띄우려고 하면
map()의 형태는 Iterable 타입이기 때문에 Widget 형태에 할당이 될 수 없다.

그러므로 ... casecade 이용하여 리스트를 하나씩 Widget 형태로 반환을 해줘야 한다.

https://neopathos.medium.com/dart-%EB%AC%B8%EB%B2%95%EA%B3%B5%EB%B6%80-cascade-spred-operator-46e198536cda
```

