### PR TITLE
feat:category card

### DIFF
--- a/lib/component/category_card.dart
+++ b/lib/component/category_card.dart
@@ -1,0 +1,71 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
+
+import '../const/colors.dart';
+import 'name_stat.dart';
+
+class CategoryCard extends StatelessWidget {
+  const CategoryCard({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      height: 160,
+      child: Card(
+        margin: EdgeInsets.symmetric(horizontal: 8.0),
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.all(
+            Radius.circular(16.0),
+          ),
+        ),
+        color: lightColor,
+        child: LayoutBuilder(
+          builder: (context, Constraints) {
+            return Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                Container(
+                  decoration: BoxDecoration(
+                    color: darkColor,
+                    borderRadius: BorderRadius.only(
+                      topLeft: Radius.circular(16.0),
+                      topRight: Radius.circular(16.0),
+                    ),
+                  ),
+                  child: Padding(
+                    padding: const EdgeInsets.all(4.0),
+                    child: Text(
+                      '종류별 통계',
+                      style: TextStyle(
+                        color: Colors.white,
+                        fontWeight: FontWeight.w700,
+                      ),
+                      textAlign: TextAlign.center,
+                    ),
+                  ),
+                ),
+                Expanded(
+                  // 스크롤 가능한 위젯은 Column안에서 사용할때는 반드시 Expaned를 해줘야함 -> 안하면 오류 발생
+                  child: ListView(
+                    scrollDirection: Axis.horizontal, // 스크롤 가로 모드
+                    physics: PageScrollPhysics(), // 스크롤을 할때 페이지 단위로 넘어가는 액션
+                    children: List.generate(
+                      20,
+                      (index) => MainStat(
+                        width: Constraints.maxWidth / 3,
+                        category: '미세먼지',
+                        imgPath: 'asset/img/best.png',
+                        level: '최고',
+                        stat: '0㎍/㎥',
+                      ),
+                    ),
+                  ),
+                )
+              ],
+            );
+          }
+        ),
+      ),
+    );
+  }
+}

--- a/lib/component/name_stat.dart
+++ b/lib/component/name_stat.dart
@@ -1,0 +1,57 @@
+import 'package:flutter/material.dart';
+
+class MainStat extends StatelessWidget {
+  // 미세먼지 / 초미세먼지 등
+  final String category;
+  // 아이콘 위치(경로)
+  final String imgPath;
+  // 오염 정도
+  final String level;
+  // 오염 수치
+  final String stat;
+  // 너비
+  final double width;
+
+  const MainStat({
+    super.key,
+    required this.category,
+    required this.imgPath,
+    required this.level,
+    required this.stat,
+    required this.width,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final ts = TextStyle(
+      color: Colors.black,
+    );
+
+    return SizedBox(
+      width: width,
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Text(
+            category,
+            style: ts,
+          ),
+          const SizedBox(height: 8.0),
+          Image.asset(
+            imgPath,
+            width: 50.0,
+          ),
+          const SizedBox(height: 8.0),
+          Text(
+            level,
+            style: ts,
+          ),
+          Text(
+            stat,
+            style: ts,
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/screen/home_screen.dart
+++ b/lib/screen/home_screen.dart
@@ -1,3 +1,4 @@
+import 'package:dusty_dust/component/category_card.dart';
 import 'package:dusty_dust/component/main_app_bar.dart';
 import 'package:dusty_dust/component/main_drawer.dart';
 import 'package:dusty_dust/const/colors.dart';
@@ -14,6 +15,15 @@ class HomeScreen extends StatelessWidget {
       body: CustomScrollView(
         slivers: [
           MainAppBar(),
+          SliverToBoxAdapter(
+            // Sliver에 일반 위젯을 넣게 해줌
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                CategoryCard(),
+              ],
+            ),
+          ),
         ],
       ),
     );


### PR DESCRIPTION
### 2023/08/23 (수) - CategoryCard

---

<center><h3>Files List</h3></center>

<p align="center">
<img width="332" alt="image" src="https://github.com/baka9131/project-dusty-dust/assets/93738662/c2f334bd-b7e4-44e5-9047-d86f614ccda5">
</p>

---

<p align="center">
<img width="305" alt="image" src="https://github.com/baka9131/project-dusty-dust/assets/93738662/96730fc6-8f68-432e-afda-f21d72ea0b0a">
</p>



+ Card() 위젯을 사용하여 카드 형식의 Horizontal 스크롤 구현



```dart
Expanded( // 스크롤 가능한 위젯은 Column안에서 사용할때는 반드시 Expaned를 해줘야함 -> 안하면 오류 발생
                child: ListView(
                  scrollDirection: Axis.horizontal, // 스크롤 가로 모드
                  physics: PageScrollPhysics(), // 스크롤을 할때 페이지 단위로 넘어가는 액션
                  children: List.generate(
                    20,
                    (index) => MainStat(
                      width: constraints.maxWidth / 3,
                      category: '미세먼지',
                      imgPath: 'asset/img/best.png',
                      level: '최고',
                      stat: '0㎍/㎥',
                    ),
                  ),
                ),
              ),
```



위 코드에서 새로 알게 된 점과 주의해야 할 점을 2가지 알게 되었다.

1. ListView를 Column안에 사용할시 반드시 Expaned를 하여 최대 넓이를 가져다 주어야 한다.
2. LayoutBuilder를 사용하여 내가 원하는 위젯의 MAX,MIN의 width,height 값을 가져 올 수 있다.



```dar
LayoutBuilder(builder: (context, constraints) {
...
child: ListView(
                    (index) => MainStat(
                      width: constraints.maxWidth / 3,
                    ),
```

LayoutBuilder를 내가 알고 싶은 위젯에 감싼 후에 constraints를 통해 이 위젯이 최대,최소의 가로 또는 높이의 값을 가져올 수 있다. 이를 사용시 매우 효율적으로 위젯을 배치 할 수 있게 된다.



위 코드에서는 constraints를 통해 위젯의 MAX 가로 값을 가져와서 / 3 을 하여 최대 3개의 List 값을 가져오게 설정 하였다.